### PR TITLE
Removed references to local test files

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -34,11 +34,6 @@ module.exports = {
         { from: 'popup.html', to: 'popup.html' },
         { from: 'content.css', to: 'content.css' },
         { from: 'src/mermaid-render.js', to: 'mermaid-render.js' },
-        { from: 'test.html', to: 'test.html' },
-        { from: 'test-langgraph.html', to: 'test-langgraph.html' },
-        { from: 'test-background.html', to: 'test-background.html' },
-        { from: 'test-init.html', to: 'test-init.html' },
-        { from: 'debug.html', to: 'debug.html' },
         { from: 'README.md', to: 'README.md' }
       ]
     }),


### PR DESCRIPTION
Hi Mahadev
Removed references to local test files in webpack config. Probably these are local test files; not intended to be committed to the repo. Please review.

```sh
$ npm run build
assets by status 973 KiB [cached] 8 assets]

ERROR in unable to locate 'C:/Users/abc/ai-browser-assistant/test.html' glob
ERROR in unable to locate 'C:/Users/abc/ai-browser-assistant/test-langgraph.html' glob
ERROR in unable to locate 'C:/Users/abc/ai-browser-assistant/test-background.html' glob
ERROR in unable to locate 'C:/Users/abc/ai-browser-assistant/test-init.html' glob
ERROR in unable to locate 'C:/Users/abc/ai-browser-assistant/debug.html' glob

webpack 5.101.3 compiled with 5 errors in 16671 ms

```
